### PR TITLE
Declare :inets as a dependent app in mix.exs

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -1,6 +1,5 @@
 defmodule Client do
   defp get do
-    :inets.start
     {:ok, {_, _, content}} = :httpc.request 'http://localhost:9292'
     content
   end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Client.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :inets]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
Add :inets as a dependent app, so it gets started on application
startup; this removes the need from having to call `:inets:start`
in the client right before we are making the call to
:httpc.request in the `get` method of the Client module.
