### PR TITLE
Concurrent vs Serial requests timings

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -21,4 +21,34 @@ defmodule Client do
   end
 end
 
+defmodule Spawner do
+  def spawn_tasks(count, function) do
+    1..count
+      |> Enum.map( fn(_) -> Task.async(function) end )
+      |> Enum.map( &Task.await/1 )
+  end
+end
+
+defmodule SerialRunner do
+  def execute(count, function) do
+    1..count
+      |> Enum.map( fn(_) -> function.() end)
+  end
+end
+
 Client.get_JSON
+
+connections = 100
+
+IO.puts "running baseline tasks for timing"
+{timing_tasks_baseline, _result} = :timer.tc(Spawner, :spawn_tasks, [connections, fn() -> 1 end])
+
+IO.puts "running via tasks"
+{timing_tasks, _result} = :timer.tc(Spawner, :spawn_tasks, [connections, &Client.get_JSON/0])
+
+IO.puts "running via serial map"
+{timing_serial, _result} = :timer.tc(SerialRunner, :execute, [connections, &Client.get_JSON/0])
+
+IO.puts "running #{connections} baseline tasks took #{timing_tasks_baseline} microseconds"
+IO.puts "running #{connections} tasks took #{timing_tasks} microseconds"
+IO.puts "running #{connections} in a map took #{timing_serial} microseconds"


### PR DESCRIPTION
From our conversation about doing concurrent versus serial
requests, and what the timings look like between spawning a Task
asynchronously to run concurrently for each web request, and doing
a simple map to kick off requests serially.

I have added in calls to `:timer.tc` which will return a tuple
with the first item being the time in _micro_ seconds it took for
the operation to complete, and the second is the result (which
is just being thrown away since it is being outputed via IO.puts).

I have included the timings of just kicking off N number of tasks
as well that just return the value `1` for a baseline to see how
long it takes for those to be spawned up and completed.
